### PR TITLE
Fix issue with trailing "in."

### DIFF
--- a/harvard-cite-them-right.csl
+++ b/harvard-cite-them-right.csl
@@ -266,8 +266,11 @@
   <macro name="container-prefix">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <text term="in"/>
-      </if>
+        <choose>
+          <if variable="container-title">
+            <text term="in"/>
+          </if>
+        </choose>
     </choose>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">


### PR DESCRIPTION
This makes a small tweak to the Harvard CTR style.

I noticed that there is an issue with my own Conference Paper references. If I have no Proceedings Title set, then it would lead to a trailing "in." after the Title, for example:

```
Decan, A., Mens, T. and Claes, M. (2017) ‘An empirical comparison of dependency issues in OSS packaging ecosystems’, in. 2017 IEEE 24th International Conference on Software Analysis, Evolution and Reengineering (SANER), pp. 2–12. Available at: https://doi.org/10.1109/SANER.2017.7884604.
```

This PR changes it so that this is only included if the title is also included.

```
Decan, A., Mens, T. and Claes, M. (2017) ‘An empirical comparison of dependency issues in OSS packaging ecosystems’. 2017 IEEE 24th International Conference on Software Analysis, Evolution and Reengineering (SANER), pp. 2–12. Available at: https://doi.org/10.1109/SANER.2017.7884604.
```

Apologies if the double-nested if statement is bad practice, I'm not 100% familiar with CSL. If there are appropriate tweaks to be made then please let me know.